### PR TITLE
📖: Update multiversion-tutorial/deployment.md to enable CA injection when deploying webhook

### DIFF
--- a/docs/book/src/multiversion-tutorial/deployment.md
+++ b/docs/book/src/multiversion-tutorial/deployment.md
@@ -12,8 +12,8 @@ bits disabled. To enable them, we need to:
 - Enable `../certmanager` and `../webhook` directories under the
   `bases` section in `config/default/kustomization.yaml` file.
 
-- Enable `manager_webhook_patch.yaml` under the `patches` section
-  in `config/default/kustomization.yaml` file.
+- Enable `manager_webhook_patch.yaml` and `webhookcainjection_patch.yaml`
+  under the `patches` section in `config/default/kustomization.yaml` file.
 
 - Enable all the vars under the `CERTMANAGER` section in
   `config/default/kustomization.yaml` file.


### PR DESCRIPTION
# Motivation

I followed the instructions in the documentation to deploy the webhook. When I got to the step `kubectl apply -f config/samples/batch_v2_cronjob.yaml`, kubectl reported an error:

```bash
$ kubectl apply -f config/samples/batch_v2_cronjob.yaml
Error from server (InternalError): error when creating "config/samples/batch_v2_cronjob.yaml": Internal error occurred: failed calling webhook "mcronjob.kb.io": failed to call webhook: Post "https://kubebuildertutorial-webhook-service.kubebuildertutorial-system.svc:443/mutate-batch-tutorial-kubebuilder-io-v1-cronjob?timeout=10s": x509: certificate signed by unknown authority
```

After debugging, I found that I also need to apply the `webhookcainjection_patch.yaml` patch to let `cert-manager` work as expected.
